### PR TITLE
fix: create parents on harpoon--create-directory

### DIFF
--- a/harpoon.el
+++ b/harpoon.el
@@ -133,7 +133,7 @@
 (defun harpoon--create-directory ()
   "Create harpoon cache dir if doesn't exist."
   (unless (f-directory? harpoon-cache-file)
-    (make-directory harpoon-cache-file)))
+    (make-directory harpoon-cache-file t)))
 
 (defun harpoon--file-name ()
   "File name for harpoon on current project."


### PR DESCRIPTION
This was calling make-directory without setting parents to `t` which
would throw an error if `.local` did not exist on the emacs dir