### PR TITLE
Fix function to get project name for builtin project.el

### DIFF
--- a/harpoon.el
+++ b/harpoon.el
@@ -110,7 +110,7 @@
 
 (defun harpoon--get-project-name-for-project ()
   "Return projects name for project."
-  (let* ((splitted-project-path (split-string (cdr (project-current)) "/"))
+  (let* ((splitted-project-path (split-string (car (last (project-current))) "/"))
          (splitted-length (length splitted-project-path))
          (project-name (nth (- splitted-length 2) splitted-project-path)))
     project-name))


### PR DESCRIPTION
The `project-current` function returns something like `(vc Git "~/.config/emacs/elpaca/repos/harpoon/")` which if we just take `cdr` does not return the project path. This errors out resulting in the function returning nil. This fixes the issue by taking the last element.